### PR TITLE
Fixed reading of archives with files >2Gb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging-api</artifactId>
 			<version>1.1</version>
-			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/com/github/junrar/rarfile/BlockHeader.java
+++ b/src/main/java/com/github/junrar/rarfile/BlockHeader.java
@@ -35,8 +35,8 @@ public class BlockHeader extends BaseBlock{
 	
 	private Log logger = LogFactory.getLog(BlockHeader.class.getName());
 	
-	private int dataSize;
-	private int packSize;
+	private long dataSize;
+	private long packSize;
     
     public BlockHeader(){
     	
@@ -53,15 +53,15 @@ public class BlockHeader extends BaseBlock{
     {
     	super(bb);
     	
-    	this.packSize = Raw.readIntLittleEndian(blockHeader, 0);
+    	this.packSize = Raw.readIntLittleEndianAsLong(blockHeader, 0);
     	this.dataSize  = this.packSize;
     }
     
-	public int getDataSize() {
+	public long getDataSize() {
 		return dataSize;
 	}
 	
-	public int getPackSize() {
+	public long getPackSize() {
 		return packSize;
 	}
     


### PR DESCRIPTION
Test RAR archive can be found here:
http://fias.nalog.ru/Public/Downloads/20151005/fias_xml.rar

InputStream of AS_HOUSE_*.XML entry always returns -1 (EOF).
This was fixed.
