### PR TITLE
update dependency to fix security bug of dependent libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,10 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-vfs2</artifactId>
-			<version>2.0</version>
+			<version>2.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>1.3.2</version>
 			<scope>test</scope>
@@ -86,7 +86,7 @@
 						</manifest>
 						<manifestEntries>
 							<mode>development</mode>
-							<url>${pom.url}</url>
+							<url>${project.url}</url>
 						</manifestEntries>
 						<manifestFile>
 							src/main/resources/META-INF/MANIFEST.MF


### PR DESCRIPTION
Hello,

the old version 2.0 contains (within an dependency down the road) some security problems which are fixed with updating to version 2.1 of commons-vfs2.

Further more i fixed 2 maven warnings within the pom without changing the versions itself.

The security problems and links to more informations are:

✗ Medium severity vulnerability found on org.codehaus.plexus:plexus-utils@1.5.6
- desc: Directory Traversal
- info: https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521
- from: com.github.junrar:junrar@0.7 > org.apache.commons:commons-vfs2@2.0 > org.apache.maven.scm:maven-scm-api@1.4 > org.codehaus.plexus:plexus-utils@1.5.6

✗ High severity vulnerability found on org.codehaus.plexus:plexus-utils@1.5.6
- desc: Shell Command Injection
- info: https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31522
- from: com.github.junrar:junrar@0.7 > org.apache.commons:commons-vfs2@2.0 > org.apache.maven.scm:maven-scm-api@1.4 > org.codehaus.plexus:plexus-utils@1.5.6

Please create a new version 0.8 of your library afterwards to let dependent projects fix this vulnerabilities too.

Thanks,
Stefan Seide