### PR TITLE
Minor updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,19 +39,18 @@
 	<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.10</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging-api</artifactId>
-			<version>1.1</version>
-			<type>jar</type>
+			<artifactId>commons-logging</artifactId>
+			<version>1.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-vfs2</artifactId>
-			<version>2.0</version>
+			<version>2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -70,7 +69,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.2</version>
+				<version>2.6</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -105,7 +104,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>2.3.2</version>
+						<version>3.7.0</version>
 						<configuration>
 							<source>${maven.compiler.source}</source>
 							<target>${maven.compiler.source}</target>

--- a/src/main/java/com/github/junrar/Archive.java
+++ b/src/main/java/com/github/junrar/Archive.java
@@ -168,6 +168,15 @@ public class Archive implements Closeable {
 	}
 
 	/**
+	 * Gets all of the headers in the archive.
+	 *
+	 * @return returns the headers.
+	 */
+	public List<BaseBlock> getHeaders() {
+		return new ArrayList<BaseBlock>(headers);
+	}
+
+	/**
 	 * @return returns all file headers of the archive
 	 */
 	public List<FileHeader> getFileHeaders() {

--- a/src/main/java/com/github/junrar/io/Raw.java
+++ b/src/main/java/com/github/junrar/io/Raw.java
@@ -151,7 +151,7 @@ public class Raw {
      * @return the value
      */
     public static final long readLongLittleEndian(byte[] array, int pos) {
-	int temp = 0;
+	long temp = 0;
 	temp |= array[pos + 7] & 0xff;
 	temp <<= 8;
 	temp |= array[pos + 6] & 0xff;
@@ -166,7 +166,7 @@ public class Raw {
 	temp <<= 8;
 	temp |= array[pos + 1] & 0xff;
 	temp <<= 8;
-	temp |= array[pos];
+	temp |= array[pos] & 0xff;
 	return temp;
     }
 

--- a/src/main/java/com/github/junrar/rarfile/BlockHeader.java
+++ b/src/main/java/com/github/junrar/rarfile/BlockHeader.java
@@ -35,8 +35,8 @@ public class BlockHeader extends BaseBlock{
 	
 	private Log logger = LogFactory.getLog(BlockHeader.class.getName());
 	
-	private int dataSize;
-	private int packSize;
+	private long dataSize;
+	private long packSize;
     
     public BlockHeader(){
     	
@@ -53,15 +53,15 @@ public class BlockHeader extends BaseBlock{
     {
     	super(bb);
     	
-    	this.packSize = Raw.readIntLittleEndian(blockHeader, 0);
+    	this.packSize = Raw.readIntLittleEndianAsLong(blockHeader, 0);
     	this.dataSize  = this.packSize;
     }
     
-	public int getDataSize() {
+	public long getDataSize() {
 		return dataSize;
 	}
 	
-	public int getPackSize() {
+	public long getPackSize() {
 		return packSize;
 	}
     

--- a/src/main/java/com/github/junrar/rarfile/FileHeader.java
+++ b/src/main/java/com/github/junrar/rarfile/FileHeader.java
@@ -178,8 +178,8 @@ public class FileHeader extends BlockHeader {
 	    }
 
 	    if (NewSubHeaderType.SUBHEAD_TYPE_RR.byteEquals(fileNameBytes)) {
-		recoverySectors = subData[8] + (subData[9] << 8)
-			+ (subData[10] << 16) + (subData[11] << 24);
+		recoverySectors = (subData[8] & 0xff) + ((subData[9] & 0xff) << 8)
+			+ ((subData[10] & 0xff) << 16) + ((subData[11] & 0xff) << 24);
 	    }
 	}
 

--- a/src/main/java/com/github/junrar/unpack/vm/RarVM.java
+++ b/src/main/java/com/github/junrar/unpack/vm/RarVM.java
@@ -931,7 +931,7 @@ public class RarVM extends BitInput {
 		        for (int curPos=0;curPos<dataSize-4;)
 		        {
 		          byte curByte=mem[curPos++];
-		          if (curByte==0xe8 || curByte==cmpByte2)
+		          if (curByte==((byte) 0xe8) || curByte==cmpByte2)
 		          {
 //		#ifdef PRESENT_INT32
 //		            sint32 Offset=CurPos+FileOffset;

--- a/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileObject.java
+++ b/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileObject.java
@@ -35,7 +35,7 @@ import com.github.junrar.rarfile.FileHeader;
  * 
  * @author <a href="http://www.rogiel.com">Rogiel</a>
  */
-public class RARFileObject extends AbstractFileObject implements FileObject {
+public class RARFileObject extends AbstractFileObject<RARFileSystem> implements FileObject {
 	/**
 	 * The TFile.
 	 */

--- a/src/test/java/com/github/junrar/MVTest.java
+++ b/src/test/java/com/github/junrar/MVTest.java
@@ -38,6 +38,7 @@ public class MVTest {
 					System.out.println(out.getAbsolutePath());
 					FileOutputStream os = new FileOutputStream(out);
 					a.extractFile(fh, os);
+					os.flush();
 					os.close();
 				} catch (FileNotFoundException e) {
 					// TODO Auto-generated catch block


### PR DESCRIPTION
As [discussed](https://github.com/junrar/junrar/commit/c6ef2fc3b40d5ae11bcdb359d6f568ca82ccfd96#commitcomment-28717784) I made some minor updates that I think should be "safe".

I've updated the dependencies as much as possible while maintaining Java 6 compatibility, and looked at various forks and picked up a couple of things that seem useful. I also ran FindBugs and took care of the most obvious stuff.

I've successfully built it with Java 6, and run tests on a few different files. During testing I tested extracting a 3.5 GB file both from one large archive and several smaller pieces as well as other "random" smaller RAR files I found.

The code style/formatting is very foreign to me, so I have a hard time getting a grasp of what is done some places. I didn't want to reformat everything because the diffs would be huge, but it limits my ability to verify the correctness of the code. FindBugs issues 84 warning as the code is now, but most of it is minor stuff as far as I can see. There are some questionable byte <-> String conversions using the default (JVM) encoding that most definitly can lead to real problems, but correcting that would mean changing the API or investigating the format specs enough to know if only a defined encoding is in use.

The biggest problem I found is that the [RAR 5.0 archive format](https://www.rarlab.com/technote.htm) isn't supported at all. That means that RAR archives made with more recent versions of RAR won't be extractable. While I found an up to date [C++ source code](https://www.rarlab.com/rar/unrarsrc-5.6.3.tar.gz), I'm not up for such a big task.

It's still useful for the "RAR 4 format" though, and I suppose there are no reason to use the proprietary RAR format for newer archives when free/open alternatives exists.

There's no need to add me as a contributor, I'm not planning to maintain this on a regular basis. My issue is simply that some of the dependencies are so outdated that it creates problems for us when making an "uber JAR" because of dependency collisions with more recent libraries.