### PR TITLE
The maven surefire plugin will only detect tests which end on *Test

### DIFF
--- a/src/test/java/com/github/junrar/JunrarTest.java
+++ b/src/test/java/com/github/junrar/JunrarTest.java
@@ -19,7 +19,7 @@ import com.github.junrar.exception.RarException;
 import com.github.junrar.impl.FileVolumeManager;
 import com.github.junrar.testUtil.JUnRarTestUtil;
 
-public class JunrarTests {
+public class JunrarTest {
 	private static File tempFolder;
 
 	@BeforeClass


### PR DESCRIPTION
Fixes #19 
The `JUnRarTestUtil` is still not executed but I would vote for deleting the whole class since the performed test is covered by `JunrarTest#extractionFromFileHappyDay`.
@beothorn I also think it would be good if we can enable some CI tool for automated test execution (TravisCI, CircleCI, ...)