### PR TITLE
Replace deprecated <tt>XXX</tt> tag with {@code XXX}

### DIFF
--- a/src/main/java/com/github/junrar/UnrarCallback.java
+++ b/src/main/java/com/github/junrar/UnrarCallback.java
@@ -11,10 +11,8 @@ public interface UnrarCallback {
     /**
      * @param nextVolume ,
      *
-     * @return <tt>true</tt> if the next volume is ready to be processed,
-     * <tt>false</tt> otherwise.
-     *
-     *
+     * @return {@code true} if the next volume is ready to be processed,
+     *         {@code false} otherwise.
      */
     boolean isNextVolumeReady(Volume nextVolume);
 

--- a/src/main/java/com/github/junrar/io/SeekableReadOnlyByteChannel.java
+++ b/src/main/java/com/github/junrar/io/SeekableReadOnlyByteChannel.java
@@ -50,7 +50,7 @@ public interface SeekableReadOnlyByteChannel {
     int read() throws IOException;
 
     /**
-     * Read up to <tt>count</tt> bytes to the specified buffer.
+     * Read up to {@code count} bytes to the specified buffer.
      *
      * @param buffer .
      * @param off .
@@ -64,7 +64,7 @@ public interface SeekableReadOnlyByteChannel {
     int read(byte[] buffer, int off, int count) throws IOException;
 
     /**
-     * Read exactly <tt>count</tt> bytes to the specified buffer.
+     * Read exactly {@code count} bytes to the specified buffer.
      *
      * @param buffer where to store the read data
      * @param count how many bytes to read


### PR DESCRIPTION
Fix the error while building library on Java 14:
> error: tag not supported in the generated HTML version: tt