### PR TITLE
Reuse threads on extract to InputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [7.4.1](https://github.com/andrebrait/junrar/compare/v7.4.0...v7.4.1) (2022-03-02)
+
+
+### Bug Fixes
+
+* invalid subheader type would throw npe and make the extract loop ([7b16b3d](https://github.com/andrebrait/junrar/commit/7b16b3d90b91445fd6af0adfed22c07413d4fab7)), closes [#73](https://github.com/andrebrait/junrar/issues/73)
+
 ## [7.4.1](https://github.com/junrar/junrar/compare/v7.4.0...v7.4.1) (2022-01-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [7.5.0](https://github.com/andrebrait/junrar/compare/v7.4.1...v7.5.0) (2022-03-09)
+
+
+### Features
+
+* allow disabling the thread pool executor ([8bd46f6](https://github.com/andrebrait/junrar/commit/8bd46f693f71f59b8010fb53b6acb0e6bd7e8509))
+
 ## [7.4.1](https://github.com/andrebrait/junrar/compare/v7.4.0...v7.4.1) (2022-03-02)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Commit messages are enforced using commit hooks ran on the developer's PC. To in
 
 ## Build process with Gradle
 
-The project uses Gradle for the build. You do not need to install Gradle, the Gradle wrapepr will install the required version for you.
+The project uses Gradle for the build. You do not need to install Gradle, the Gradle wrapper will install the required version for you.
 
 To run the tests, just run `./gradlew check`.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.4.1
+version=7.5.0

--- a/src/test/java/com/github/junrar/ArchiveTest.java
+++ b/src/test/java/com/github/junrar/ArchiveTest.java
@@ -19,6 +19,7 @@ package com.github.junrar;
 import com.github.junrar.exception.CrcErrorException;
 import com.github.junrar.exception.UnsupportedRarV5Exception;
 import com.github.junrar.rarfile.FileHeader;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -80,6 +81,31 @@ public class ArchiveTest {
 
                         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                             archive.extractFile(fileHeaders.get(i), baos);
+                            assertThat(baos.toString()).isEqualTo("file" + index + "\n");
+                        }
+                    }
+                }
+            }
+        }
+
+        @Test
+        public void givenSolidRar4File_whenExtractingInOrder_thenExtractionIsDone_withInputStream() throws Exception {
+            try (InputStream is = getClass().getResourceAsStream("solid/rar4-solid.rar")) {
+                try (Archive archive = new Archive(is)) {
+                    assertThat(archive.getMainHeader().isSolid()).isTrue();
+
+                    List<FileHeader> fileHeaders = archive.getFileHeaders();
+                    assertThat(fileHeaders).hasSize(9);
+
+                    for (int i = 0; i < fileHeaders.size(); i++) {
+                        int index = i + 1;
+                        FileHeader fileHeader = fileHeaders.get(i);
+                        assertThat(fileHeader.getFileName()).isEqualTo("file" + index + ".txt");
+
+                        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                            try (InputStream fis = archive.getInputStream(fileHeaders.get(i))) {
+                                IOUtils.copy(fis, baos);
+                            }
                             assertThat(baos.toString()).isEqualTo("file" + index + "\n");
                         }
                     }


### PR DESCRIPTION
Creating a new Thread whenever reading from an `InputStream` was quite expensive.
This replaces the creation of a new thread with using a `ThreadPoolExecutor`, allowing for reusing threads.
The executor is lazily initialized, which means that, unless the user actually calls the `getInputStream(FileHeader hd)` method, it won't be initialized.

Just for the sake of "what if the user needs to configure it?", I added the ability to set a maximum number of threads and adjust the keep alive time through system properties. 

The unbounded default executor is virtually similar to the creation of a new thread on every execution in that only a maximum of X amount of threads will exist, where X is the maximum number of concurrent method calls.