### PR TITLE
Allow local unsigned builds and ensure compatibility with Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ def isNonStable = { String version ->
     def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
     def regex = /^[0-9,.v-]+(-r)?$/
     return !stableKeyword && !(version ==~ regex)
-} as Object
+}
 tasks.named("dependencyUpdates").configure {
     // disallow release candidates as upgradable versions from stable versions
     rejectVersionIf {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'signing'
     id 'checkstyle'
     id 'jacoco'
     id 'com.github.ben-manes.versions' version '0.38.0'
@@ -85,17 +86,12 @@ publishing {
     }
 }
 
-// Run Gradle with '-Pskip.signing' to skip signing the artifact
-// Useful for testing it locally on another project
-// Ex.: ./gradlew publishToMavenLocal "-Pskip.signing"
-if (!project.hasProperty('skip.signing')) {
-    apply plugin: 'signing'
-    signing {
-        def signingKey = findProperty('signingKey')
-        def signingPassword = findProperty('signingPassword')
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign publishing.publications.mavenJava
-    }
+signing {
+    required { false }
+    def signingKey = findProperty('signingKey')
+    def signingPassword = findProperty('signingPassword')
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.mavenJava
 }
 
 nexusPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'signing'
     id 'checkstyle'
     id 'jacoco'
     id 'com.github.ben-manes.versions' version '0.38.0'
@@ -15,22 +14,31 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.slf4j:slf4j-api:1.7.30'
+    implementation 'org.slf4j:slf4j-api:1.7.36'
 
-    testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
-    testImplementation 'commons-io:commons-io:2.8.0'
-    testImplementation 'org.mockito:mockito-core:3.8.0'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
-    testImplementation("com.tngtech.archunit:archunit-junit5:0.17.0")
+    testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testImplementation 'commons-io:commons-io:2.11.0'
+    testImplementation 'org.mockito:mockito-core:4.3.1'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:0.23.0'
 }
 
 group = 'com.github.junrar'
 description = 'rar decompression library in plain java'
 
+java {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+// Set the '--release' compiler option if compiling on Java > 1.8.
+// Prevents the bytecode from being incompatible with Java 8.
+compileJava {
+    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+        options.release.set(8)
+    }
+}
 
 java {
     withJavadocJar()
@@ -77,11 +85,17 @@ publishing {
     }
 }
 
-signing {
-    def signingKey = findProperty('signingKey')
-    def signingPassword = findProperty('signingPassword')
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
+// Run Gradle with '-Pskip.signing' to skip signing the artifact
+// Useful for testing it locally on another project
+// Ex.: ./gradlew publishToMavenLocal "-Pskip.signing"
+if (!project.hasProperty('skip.signing')) {
+    apply plugin: 'signing'
+    signing {
+        def signingKey = findProperty('signingKey')
+        def signingPassword = findProperty('signingPassword')
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.mavenJava
+    }
 }
 
 nexusPublishing {
@@ -119,7 +133,7 @@ def isNonStable = { String version ->
     def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
     def regex = /^[0-9,.v-]+(-r)?$/
     return !stableKeyword && !(version ==~ regex)
-}
+} as Object
 tasks.named("dependencyUpdates").configure {
     // disallow release candidates as upgradable versions from stable versions
     rejectVersionIf {


### PR DESCRIPTION
Updates a few testing dependencies and:

- Ensure runtime compatibility with Java 8 by compiling with `--release 8` when compiling on newer versions of Java
- ~Add `Pskip.signing` to allow for creating an unsigned jar for local usage (e.g. `.\gradlew publishToMavenLocal "-Pskip.signing"`)~
- Make signing optional