### PR TITLE
Fix parsing VMSF_UPCASE in VMStandardFilters values from raw value to enum

### DIFF
--- a/src/main/java/com/github/junrar/rarfile/UnrarHeadertype.java
+++ b/src/main/java/com/github/junrar/rarfile/UnrarHeadertype.java
@@ -68,18 +68,6 @@ public enum UnrarHeadertype {
         if (UnrarHeadertype.ProtectHeader.equals(headerType)) {
             return UnrarHeadertype.ProtectHeader;
         }
-        if (UnrarHeadertype.MarkHeader.equals(headerType)) {
-            return UnrarHeadertype.MarkHeader;
-        }
-        if (UnrarHeadertype.MainHeader.equals(headerType)) {
-            return UnrarHeadertype.MainHeader;
-        }
-        if (UnrarHeadertype.FileHeader.equals(headerType)) {
-            return UnrarHeadertype.FileHeader;
-        }
-        if (UnrarHeadertype.EndArcHeader.equals(headerType)) {
-            return UnrarHeadertype.EndArcHeader;
-        }
         if (UnrarHeadertype.CommHeader.equals(headerType)) {
             return UnrarHeadertype.CommHeader;
         }
@@ -89,7 +77,7 @@ public enum UnrarHeadertype {
         return null;
     }
 
-    private byte headerByte;
+    private final byte headerByte;
 
     UnrarHeadertype(byte headerByte) {
         this.headerByte = headerByte;

--- a/src/main/java/com/github/junrar/unpack/vm/VMStandardFilters.java
+++ b/src/main/java/com/github/junrar/unpack/vm/VMStandardFilters.java
@@ -24,14 +24,14 @@ package com.github.junrar.unpack.vm;
  * @version $LastChangedRevision$
  */
 public enum VMStandardFilters {
-    VMSF_NONE((int) 0),
-    VMSF_E8((int) 1),
-    VMSF_E8E9((int) 2),
-    VMSF_ITANIUM((int) 3),
-    VMSF_RGB((int) 4),
-    VMSF_AUDIO((int) 5),
-    VMSF_DELTA((int) 6),
-    VMSF_UPCASE((int) 7);
+    VMSF_NONE(0),
+    VMSF_E8(1),
+    VMSF_E8E9(2),
+    VMSF_ITANIUM(3),
+    VMSF_RGB(4),
+    VMSF_AUDIO(5),
+    VMSF_DELTA(6),
+    VMSF_UPCASE(7);
 
     private final int filter;
 
@@ -72,6 +72,9 @@ public enum VMStandardFilters {
         }
         if (VMSF_DELTA.equals(filter)) {
             return VMSF_DELTA;
+        }
+        if (VMSF_UPCASE.equals(filter)) {
+            return VMSF_UPCASE;
         }
         return null;
     }

--- a/src/test/java/com/github/junrar/rarfile/HostSystemTest.java
+++ b/src/test/java/com/github/junrar/rarfile/HostSystemTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.rarfile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HostSystemTest {
+
+    @ParameterizedTest
+    @EnumSource(HostSystem.class)
+    void findHostSystem(final HostSystem hostSystem) {
+        assertThat(HostSystem.findHostSystem(hostSystem.getHostByte())).isEqualTo(hostSystem);
+    }
+
+    @Test
+    void unknownHostSystem() {
+        assertThat(HostSystem.findHostSystem((byte) 99)).isNull();
+    }
+
+}

--- a/src/test/java/com/github/junrar/rarfile/SubBlockHeaderTypeTest.java
+++ b/src/test/java/com/github/junrar/rarfile/SubBlockHeaderTypeTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.rarfile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubBlockHeaderTypeTest {
+
+    @ParameterizedTest
+    @EnumSource(SubBlockHeaderType.class)
+    void findSubblockHeaderType(final SubBlockHeaderType subBlockHeaderType) {
+        assertThat(SubBlockHeaderType.findSubblockHeaderType(subBlockHeaderType.getSubblocktype())).isEqualTo(subBlockHeaderType);
+    }
+
+    @Test
+    void unknownSubblockHeaderType() {
+        assertThat(SubBlockHeaderType.findSubblockHeaderType((short) 0)).isNull();
+    }
+
+}

--- a/src/test/java/com/github/junrar/rarfile/UnrarHeadertypeTest.java
+++ b/src/test/java/com/github/junrar/rarfile/UnrarHeadertypeTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.rarfile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnrarHeadertypeTest {
+
+    @ParameterizedTest
+    @EnumSource(UnrarHeadertype.class)
+    void findType(final UnrarHeadertype unrarHeadertype) {
+        assertThat(UnrarHeadertype.findType(unrarHeadertype.getHeaderByte())).isEqualTo(unrarHeadertype);
+    }
+
+    @Test
+    void unknownUnrarHeadertype() {
+        assertThat(UnrarHeadertype.findType((byte) 0)).isNull();
+    }
+
+}

--- a/src/test/java/com/github/junrar/unpack/ppm/BlockTypesTest.java
+++ b/src/test/java/com/github/junrar/unpack/ppm/BlockTypesTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.unpack.ppm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BlockTypesTest {
+
+    @ParameterizedTest
+    @EnumSource(BlockTypes.class)
+    void findBlockType(final BlockTypes blockTypes) {
+        assertThat(BlockTypes.findBlockType(blockTypes.getBlockType())).isEqualTo(blockTypes);
+    }
+
+    @Test
+    void unknownBlockType() {
+        assertThat(BlockTypes.findBlockType(2)).isNull();
+    }
+
+}

--- a/src/test/java/com/github/junrar/unpack/vm/VMCommandsTest.java
+++ b/src/test/java/com/github/junrar/unpack/vm/VMCommandsTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.unpack.vm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VMCommandsTest {
+
+    @ParameterizedTest
+    @EnumSource(VMCommands.class)
+    void findVMCommand(final VMCommands vmCommands) {
+        assertThat(VMCommands.findVMCommand(vmCommands.getVMCommand())).isEqualTo(vmCommands);
+    }
+
+    @Test
+    void unknownVMCommand() {
+        assertThat(VMCommands.findVMCommand(55)).isNull();
+    }
+
+}

--- a/src/test/java/com/github/junrar/unpack/vm/VMFlagsTest.java
+++ b/src/test/java/com/github/junrar/unpack/vm/VMFlagsTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.unpack.vm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VMFlagsTest {
+
+    @ParameterizedTest
+    @EnumSource(VMFlags.class)
+    void findFlag(final VMFlags vmFlags) {
+        assertThat(VMFlags.findFlag(vmFlags.getFlag())).isEqualTo(vmFlags);
+    }
+
+    @Test
+    void unknownVMFlags() {
+        assertThat(VMFlags.findFlag(3)).isNull();
+    }
+
+}

--- a/src/test/java/com/github/junrar/unpack/vm/VMOpTypeTest.java
+++ b/src/test/java/com/github/junrar/unpack/vm/VMOpTypeTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.unpack.vm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VMOpTypeTest {
+
+    @ParameterizedTest
+    @EnumSource(VMOpType.class)
+    void findOpType(final VMOpType vmOpType) {
+        assertThat(VMOpType.findOpType(vmOpType.getOpType())).isEqualTo(vmOpType);
+    }
+
+    @Test
+    void unknownVMOpType() {
+        assertThat(VMOpType.findOpType(4)).isNull();
+    }
+
+}

--- a/src/test/java/com/github/junrar/unpack/vm/VMStandardFiltersTest.java
+++ b/src/test/java/com/github/junrar/unpack/vm/VMStandardFiltersTest.java
@@ -1,0 +1,22 @@
+package com.github.junrar.unpack.vm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VMStandardFiltersTest {
+
+    @ParameterizedTest
+    @EnumSource(VMStandardFilters.class)
+    void findFilter(final VMStandardFilters vmStandardFilters) {
+        assertThat(VMStandardFilters.findFilter(vmStandardFilters.getFilter())).isEqualTo(vmStandardFilters);
+    }
+
+    @Test
+    void unknownVMStandardFilters() {
+        assertThat(VMStandardFilters.findFilter(8)).isNull();
+    }
+
+}


### PR DESCRIPTION
- Adds tests for all enums to check all the defined values can be successfully parsed
- Removes duplicate checks from `UnrarHeadertype`

No test currently covers the path for dealing with `VMSF_UPCASE`. So it might be that junrar is now able to extract more files if the code for this case is correct. If the code is not correct there should be no regression because extracting the archive before already would have failed.