### PR TITLE
Add SLSA provenance builder

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -1,0 +1,26 @@
+# This builds a SLSA provenance statement for the artifacts in 'artifact-list'.
+---
+name: SLSA Provenance
+on:
+  - workflow_dispatch
+
+permissions: read-all
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  ISSUE_REPOSITORY: ${{ github.repository }}
+jobs:
+  usetrw:
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
+      packages: write
+    uses: AdamKorcz/java-slsa-generator/.github/workflows/gradle-trw.yml@main
+    with:
+      rekor-log-public: true
+      jdk-version: 8
+      artifact-list: |
+        ./build/libs/junrar-GRADLE_VERSION.jar,
+        ./build/libs/junrar-GRADLE_VERSION-sources.jar,
+        ./build/libs/junrar-GRADLE_VERSION-javadoc.jar


### PR DESCRIPTION
This adds a SLSA provenance builder for junrar.

It builds the artifacts and creates the SLSA attestation for each artifact. I have added the same artifacts that are currently released like here: https://github.com/junrar/junrar/releases/tag/v7.5.4 - except for the source code.

An example run can be found here: https://github.com/AdamKorcz/junrar/actions/runs/4468649218

The builder will be merged into https://github.com/slsa-framework/slsa-github-generator.

This builder is in its early days, and I am working to mature it and make it ready for publication. As such, this might break on occasion over the next few weeks, but I will be able to fix things quickly if they do. Nonetheless, it would be great to have junrar be an early adopter and see how it runs in the real world. Perhaps releases could be published both by the SLSA builder and the current action?

The builder will also be tested on sigstore-java: https://github.com/sigstore/sigstore-java/pull/357

To read more about the SLSA framework, see https://slsa.dev/.
To read more about SLSA provenance attestations, see: https://slsa.dev/provenance/v0.2