### PR TITLE
fix: ArrayIndexOutOfBoundsException in solid RAR v20 archive extraction

### DIFF
--- a/src/main/java/com/github/junrar/unpack/Unpack20.java
+++ b/src/main/java/com/github/junrar/unpack/Unpack20.java
@@ -212,7 +212,7 @@ public abstract class Unpack20 extends Unpack15 {
         destUnpSize -= length;
 
         int destPtr = unpPtr - distance;
-        if (destPtr < Compress.MAXWINSIZE - 300 && unpPtr < Compress.MAXWINSIZE - 300) {
+        if (destPtr >= 0 && destPtr < Compress.MAXWINSIZE - 300 && unpPtr < Compress.MAXWINSIZE - 300) {
             if (destPtr + length <= unpPtr) {
                 // Case: array elements to copy from destPtr do not overlap with unpPtr target values
                 System.arraycopy(window, destPtr, window, unpPtr, length);


### PR DESCRIPTION
`CopyString20()` could crash with a negative array index when extracting solid archives. In solid mode, back-references can point to data from a previous file, making `distance` > `unpPtr` and `destPtr` negative.

The v29 copy function (`Unpack.copyString`) already guards against this with a `destPtr >= 0` check, we're just applying the same fix to `CopyString20()`.

I couldn't figure out how to easily create a minimal test archive for this, but the fix is simple enough and just follows the same pattern already used in both the v29 and v15 implementations, so it seems pretty safe.