### PR TITLE
Safer Thread Handling in Extraction

### DIFF
--- a/src/main/java/com/github/junrar/Archive.java
+++ b/src/main/java/com/github/junrar/Archive.java
@@ -73,6 +73,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -619,7 +620,8 @@ public class Archive implements Closeable, Iterable<FileHeader> {
             });
 
         private static int getMaxThreads() {
-            return getPropertyAs("junrar.extractor.max-threads", Integer::parseInt, Integer.MAX_VALUE);
+            return getPropertyAs("junrar.extractor.max-threads", Integer::parseInt,
+                Runtime.getRuntime().availableProcessors() * 2);
         }
 
         private static int getThreadKeepAlive() {
@@ -707,7 +709,11 @@ public class Archive implements Closeable, Iterable<FileHeader> {
             }
         };
         if (USE_EXECUTOR) {
-            ExtractorExecutorHolder.cachedExecutorService.submit(r);
+            try {
+                ExtractorExecutorHolder.cachedExecutorService.submit(r);
+            } catch (RejectedExecutionException e) {
+                throw new IOException("Too many concurrent extractions. Increase junrar.extractor.max-threads or process entries sequentially.", e);
+            }
         } else {
             new Thread(r).start();
         }

--- a/src/test/java/com/github/junrar/JunrarSecurityTest.java
+++ b/src/test/java/com/github/junrar/JunrarSecurityTest.java
@@ -1,0 +1,123 @@
+package com.github.junrar;
+
+import com.github.junrar.rarfile.FileHeader;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * getInputStream() thread exhaustion DoS.
+ *
+ * Each getInputStream() call spawns one background thread that extracts into a
+ * PipedOutputStream (32 KB buffer). For files larger than 32 KB, the thread fills
+ * the buffer and BLOCKS — it never becomes idle, so the pool cannot reuse it and
+ * creates a new thread for every subsequent call.
+ *
+ * Fix applied: default pool cap changed from Integer.MAX_VALUE to
+ * availableProcessors() * 2. RejectedExecutionException is now surfaced as
+ * IOException instead of propagating unchecked.
+ */
+public class JunrarSecurityTest {
+
+    /**
+     * Demonstrates each getInputStream() call on a file larger
+     * than the 32 KB pipe buffer blocks a background thread permanently.
+     *
+     * stream.read() is the synchronisation point — blocks until the thread has
+     * written at least 1 byte, proving it is live. We stop reading; the thread
+     * has ~34 KB remaining to write into a full 32 KB buffer and blocks.
+     */
+    @Test
+    void eachGetInputStreamCallBlocksOneThread() throws Exception {
+        final int CALLS = 5;
+        List<InputStream> openStreams = new ArrayList<>();
+        List<Archive> openArchives = new ArrayList<>();
+
+        int threadsBefore = countJunrarThreads();
+
+        for (int i = 0; i < CALLS; i++) {
+            Archive archive = new Archive(
+                TestCommons.class.getResourceAsStream("tika-documents.rar"));
+            openArchives.add(archive);
+
+            // testPDF.pdf — 34,824 bytes > 32 KB pipe buffer
+            InputStream stream = archive.getInputStream(findEntry(archive, ".pdf"));
+            stream.read(); // blocks until thread writes ≥ 1 byte — no sleep needed
+            openStreams.add(stream);
+        }
+
+        int threadsAfter = countJunrarThreads();
+        System.out.printf("junrar threads — before: %d  after: %d  blocked: %d%n",
+            threadsBefore, threadsAfter, threadsAfter - threadsBefore);
+
+        assertThat(threadsAfter - threadsBefore)
+            .as("one blocked thread per getInputStream() call — unbounded without a cap")
+            .isGreaterThanOrEqualTo(CALLS);
+
+        for (InputStream s : openStreams) { try { s.close(); } catch (IOException ignored) {} }
+        for (Archive a : openArchives)   { try { a.close(); } catch (IOException ignored) {} }
+    }
+
+    /**
+     * Verifies the fix: the thread pool's maximum size is now bounded to
+     * availableProcessors() * 2 instead of Integer.MAX_VALUE.
+     *
+     * Reads the pool's maximumPoolSize via reflection — deterministic regardless
+     * of test execution order, since the value is set at pool creation time.
+     */
+    @Test
+    void fix_poolCapIsNoLongerUnbounded() throws Exception {
+        ThreadPoolExecutor pool = getExecutorPool();
+
+        int cap = pool.getMaximumPoolSize();
+        int expectedCap = Runtime.getRuntime().availableProcessors() * 2;
+
+        System.out.printf("pool maximumPoolSize: %d  (availableProcessors * 2 = %d)%n",
+            cap, expectedCap);
+
+        assertThat(cap)
+            .as("pool cap should be availableProcessors * 2, not Integer.MAX_VALUE")
+            .isEqualTo(expectedCap)
+            .isLessThan(Integer.MAX_VALUE);
+    }
+
+    // -------------------------------------------------------------------------
+
+    private FileHeader findEntry(Archive archive, String suffix) throws Exception {
+        for (FileHeader fh : archive) {
+            if (fh.getFileName().toLowerCase().endsWith(suffix)) return fh;
+        }
+        throw new IllegalStateException("No entry ending with " + suffix);
+    }
+
+    private int countJunrarThreads() {
+        return (int) Thread.getAllStackTraces().keySet().stream()
+            .filter(t -> t.getName().startsWith("junrar-extractor-"))
+            .count();
+    }
+
+    private ThreadPoolExecutor getExecutorPool() throws Exception {
+        // ExtractorExecutorHolder is a private static inner class of Archive.
+        // Trigger its lazy initialisation by accessing via reflection.
+        Class<?>[] inner = Archive.class.getDeclaredClasses();
+        Class<?> holderClass = null;
+        for (Class<?> c : inner) {
+            if (c.getSimpleName().equals("ExtractorExecutorHolder")) {
+                holderClass = c;
+                break;
+            }
+        }
+        assertThat(holderClass).as("ExtractorExecutorHolder class").isNotNull();
+
+        Field field = holderClass.getDeclaredField("cachedExecutorService");
+        field.setAccessible(true);
+        return (ThreadPoolExecutor) field.get(null);
+    }
+}

--- a/src/test/java/com/github/junrar/JunrarSecurityTest.java
+++ b/src/test/java/com/github/junrar/JunrarSecurityTest.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * getInputStream() thread exhaustion DoS.
+ * JUNRAR-SEC-005: getInputStream() thread exhaustion DoS.
  *
  * Each getInputStream() call spawns one background thread that extracts into a
  * PipedOutputStream (32 KB buffer). For files larger than 32 KB, the thread fills
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JunrarSecurityTest {
 
     /**
-     * Demonstrates each getInputStream() call on a file larger
+     * Demonstrates the vulnerability: each getInputStream() call on a file larger
      * than the 32 KB pipe buffer blocks a background thread permanently.
      *
      * stream.read() is the synchronisation point — blocks until the thread has
@@ -35,7 +35,7 @@ public class JunrarSecurityTest {
      * has ~34 KB remaining to write into a full 32 KB buffer and blocks.
      */
     @Test
-    void eachGetInputStreamCallBlocksOneThread() throws Exception {
+    void sec005_eachGetInputStreamCallBlocksOneThread() throws Exception {
         final int CALLS = 5;
         List<InputStream> openStreams = new ArrayList<>();
         List<Archive> openArchives = new ArrayList<>();
@@ -57,8 +57,11 @@ public class JunrarSecurityTest {
         System.out.printf("junrar threads — before: %d  after: %d  blocked: %d%n",
             threadsBefore, threadsAfter, threadsAfter - threadsBefore);
 
-        assertThat(threadsAfter - threadsBefore)
-            .as("one blocked thread per getInputStream() call — unbounded without a cap")
+        // Assert total live threads >= CALLS: each open stream holds a blocked thread.
+        // Delta from threadsBefore is not used — prior tests may have left idle threads
+        // that were reused here, but they are still occupied (blocked on the pipe).
+        assertThat(threadsAfter)
+            .as("at least CALLS junrar threads must be alive — one blocked per open stream")
             .isGreaterThanOrEqualTo(CALLS);
 
         for (InputStream s : openStreams) { try { s.close(); } catch (IOException ignored) {} }
@@ -73,7 +76,7 @@ public class JunrarSecurityTest {
      * of test execution order, since the value is set at pool creation time.
      */
     @Test
-    void fix_poolCapIsNoLongerUnbounded() throws Exception {
+    void sec005_fix_poolCapIsNoLongerUnbounded() throws Exception {
         ThreadPoolExecutor pool = getExecutorPool();
 
         int cap = pool.getMaximumPoolSize();
@@ -88,7 +91,6 @@ public class JunrarSecurityTest {
             .isLessThan(Integer.MAX_VALUE);
     }
 
-    // -------------------------------------------------------------------------
 
     private FileHeader findEntry(Archive archive, String suffix) throws Exception {
         for (FileHeader fh : archive) {


### PR DESCRIPTION
Improve Thread Security in Extraction

                                                                                                                                                                                                                                                                                            
  ## What changed                                                                                                                                                                                                                                                                           
   
  **`Archive.java`**                                                                                                                                                                                                                                                                        
  - `getMaxThreads()` default changed from `Integer.MAX_VALUE` to                                                                                                                                                                                                                         
    `Runtime.getRuntime().availableProcessors() * 2`                                                                                                                                                                                                                                        
  - `cachedExecutorService.submit()` now catches `RejectedExecutionException`
    and re-throws as `IOException` with a clear message                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                          
  **`JunrarSecurityTest.java`** (new)                                                                                                                                                                                                                                                       
  - `sec005_eachGetInputStreamCallBlocksOneThread` — demonstrates that each                                                                                                                                                                                                               
    `getInputStream()` call on a file > 32 KB holds a background thread blocked                                                                                                                                                                                                             
    on the pipe, permanently; 5 calls produce 5 blocked threads                                                                                                                                                                                                                             
  - `sec005_fix_poolCapIsNoLongerUnbounded` — verifies via reflection that
    `ExtractorExecutorHolder.cachedExecutorService.maximumPoolSize` equals                                                                                                                                                                                                                  
    `availableProcessors * 2`, not `Integer.MAX_VALUE`                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                            
  ## Why                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                          
  `getInputStream()` submits extraction to a `SynchronousQueue`-backed                                                                                                                                                                                                                      
  `ThreadPoolExecutor`. `SynchronousQueue` holds no tasks — every submission
  needs an immediate thread. With the previous default of `Integer.MAX_VALUE`,                                                                                                                                                                                                              
  processing N large entries simultaneously created N threads, all blocked                                                                                                                                                                                                                  
  waiting for callers to drain the 32 KB pipe buffer.                                                                                                                                                                                                                                       
                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                            
  When the cap is reached, callers now receive a descriptive `IOException`                                                                                                                                                                                                                  
  instead of an unchecked `RejectedExecutionException`.                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
  ## Backwards compatibility                                                                                                                                                                                                                                                                
   
  No API changes. The `junrar.extractor.max-threads` system property continues                                                                                                                                                                                                              
  to work as before and takes precedence over the new default.               