### PR TITLE
perf: replace RarCRC.checkCrc with java.util.zip.CRC32

### DIFF
--- a/src/main/java/com/github/junrar/crc/RarCRC.java
+++ b/src/main/java/com/github/junrar/crc/RarCRC.java
@@ -26,95 +26,29 @@ package com.github.junrar.crc;
  */
 public class RarCRC {
 
-    private static final int[] crcTab;
-    static {
-        crcTab = new int[256];
-        for (int i = 0; i < 256; i++) {
-            int c = i;
-            for (int j = 0; j < 8; j++) {
-                if ((c & 1) != 0) {
-                    c >>>= 1;
-                    c ^= 0xEDB88320;
-                } else {
-                    c >>>= 1;
-                }
-            }
-            crcTab[i] = c;
-        }
-    }
-
     private RarCRC() {
     }
 
-    public static int checkCrc(int startCrc, byte[] data, int offset,
-            int count) {
-        int size = Math.min(data.length - offset, count);
-        // #if defined(LITTLE_ENDIAN) && defined(PRESENT_INT32) &&
-        // defined(ALLOW_NOT_ALIGNED_INT)
-        /*
-        for (int i = 0; (0 < size) && i < data.length - 8
-                && ((data[i + 8] & 7) != 0); i++) {
-            startCrc = crcTab[(short) (startCrc ^ data[i]) & 0x00FF] ^ (startCrc >>> 8);
-            size--;
-        }
-
-        for (int i = 0; size >= 8; i += 8) {
-            startCrc ^= data[i + 0] << 24;
-            startCrc ^= data[i + 1] << 16;
-            startCrc ^= data[i + 2] << 8;
-            startCrc ^= data[i + 3];
-
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-
-            startCrc ^= data[i + 4] << 24;
-            startCrc ^= data[i + 5] << 16;
-            startCrc ^= data[i + 6] << 8;
-            startCrc ^= data[i + 7];
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-            startCrc = crcTab[(short) startCrc & 0x00FF] ^ (startCrc >>> 8);
-            size -= 8;
-        }*/
-
-        for (int i = 0; i < size; i++) {
-/*
-            // (byte)(StartCRC^Data[I])
-            int pos = 0; // pos=0x00000000
-            pos |= startCrc; // pos=ffffffff
-
-            pos ^= data[i]; // data[0]=0x73=115dec --> pos=140
-            System.out.println(Integer.toHexString(pos));
-
-            // Only last 8 bit because CRCtab has length 256
-            pos = pos & 0x000000FF;
-            System.out.println("pos:"+pos);
-            //startCrc >>>= 8;
-
-
-            //StartCRC>>8
-            int temp =0;
-            temp|=startCrc;
-            temp >>>= 8;
-            System.out.println("temp:"+Integer.toHexString(temp));
-
-
-            startCrc = (crcTab[pos]^temp);
-            System.out.println("--"+Integer.toHexString(startCrc));*/
-
-            startCrc = (crcTab[((int) ((int) startCrc ^ (int) data[offset + i])) & 0xff] ^ (startCrc >>> 8));
-
-            //System.out.println(Integer.toHexString(startCrc));
-
-            // Original code:
-            //StartCRC=CRCTab[(byte)(StartCRC^Data[I])]^(StartCRC>>8);
-        }
-        return (startCrc);
-    }
-
+    /**
+     * Computes the legacy 16-bit checksum used by RAR 1.5 archives.
+     * <p>
+     * This is not a standard CRC-16 algorithm. It is a simple rotating-add
+     * checksum equivalent to the {@code OldCRC16} function in the original
+     * unrar source code. For each byte, it adds the byte value to the
+     * accumulator and then rotates the result left by 1 bit:
+     * <pre>
+     *   crc = crc + byte;
+     *   crc = (crc &lt;&lt; 1) | (crc &gt;&gt;&gt; 15);
+     * </pre>
+     * <p>
+     * Only used for RAR 1.5 (method 15) archives. RAR 2.0 and later use
+     * standard CRC-32 (polynomial 0xEDB88320).
+     *
+     * @param startCrc initial CRC value (typically 0 for RAR 1.5)
+     * @param data     data to compute the checksum over
+     * @param count    number of bytes to process
+     * @return the 16-bit rotating-add checksum
+     */
     public static short checkOldCrc(short startCrc, byte[] data, int count) {
         int n = Math.min(data.length, count);
         for (int i = 0; i < n; i++) {
@@ -123,20 +57,5 @@ public class RarCRC {
         }
         return (startCrc);
     }
-
-//    public static void main(String[] args)
-//    {
-//        RarCRC rc = new RarCRC();
-//        //byte[] data = { 0x72, 0x21, 0x1A, 0x07, 0x00};
-//
-//        byte[] data = {0x73 ,0x00 ,0x00 ,0x0D ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00};
-//
-//        int crc = 0x90CF;
-//
-//
-//        int result = rc.checkCrc(0xFFFFffff, data,0,data.length);
-//        System.out.println("3: "+Integer.toHexString(~result&0xffff));
-//
-//    }
 
 }

--- a/src/main/java/com/github/junrar/unpack/ComprDataIO.java
+++ b/src/main/java/com/github/junrar/unpack/ComprDataIO.java
@@ -32,6 +32,7 @@ import javax.crypto.Cipher;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.zip.CRC32;
 
 /**
  * DOCUMENT ME
@@ -70,6 +71,8 @@ public class ComprDataIO {
     private long processedArcSize, totalArcSize;
 
     private long packFileCRC, unpFileCRC, packedCRC;
+    private CRC32 unpCrc32;
+    private CRC32 packCrc32;
 
     private int encryption;
 
@@ -97,6 +100,8 @@ public class ComprDataIO {
         packFileCRC = unpFileCRC = packedCRC = 0xffffffff;
         subHead = null;
         processedArcSize = totalArcSize = 0;
+        unpCrc32 = new CRC32();
+        packCrc32 = new CRC32();
     }
 
     public void init(FileHeader hd) throws IOException, RarException {
@@ -108,6 +113,8 @@ public class ComprDataIO {
         curUnpRead = 0;
         curPackWrite = 0;
         packedCRC = 0xFFffFFff;
+        unpCrc32.reset();
+        packCrc32.reset();
 
         if (hd.isEncrypted()) {
             try {
@@ -129,7 +136,8 @@ public class ComprDataIO {
             }
 
             if (subHead.isSplitAfter()) {
-                packedCRC = RarCRC.checkCrc((int) packedCRC, addr, offset, retCode);
+                packCrc32.update(addr, offset, retCode);
+                packedCRC = (int) (~packCrc32.getValue());
             }
 
             totalRead += retCode;
@@ -186,7 +194,8 @@ public class ComprDataIO {
             if (archive.isOldFormat()) {
                 unpFileCRC = RarCRC.checkOldCrc((short) unpFileCRC, addr, count);
             } else {
-                unpFileCRC = RarCRC.checkCrc((int) unpFileCRC, addr, offset, count);
+                unpCrc32.update(addr, offset, count);
+                unpFileCRC = (int) (~unpCrc32.getValue());
             }
         }
         // if (!skipArcCRC) {

--- a/src/main/java/com/github/junrar/unpack/vm/RarVM.java
+++ b/src/main/java/com/github/junrar/unpack/vm/RarVM.java
@@ -17,11 +17,11 @@
  */
 package com.github.junrar.unpack.vm;
 
-import com.github.junrar.crc.RarCRC;
 import com.github.junrar.io.Raw;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.zip.CRC32;
 
 
 /**
@@ -900,7 +900,9 @@ public class RarVM extends BitInput {
                 new VMStandardFilterSignature(216, 0xbc85e701, VMStandardFilters.VMSF_AUDIO),
                 new VMStandardFilterSignature(40, 0x46b9c560, VMStandardFilters.VMSF_UPCASE)
         };
-        int CodeCRC = RarCRC.checkCrc(0xffffffff, code, 0, code.length) ^ 0xffffffff;
+        CRC32 crc32 = new CRC32();
+        crc32.update(code, 0, code.length);
+        int CodeCRC = (int) crc32.getValue();
         for (int i = 0; i < stdList.length; i++) {
             if (stdList[i].getCRC() == CodeCRC && stdList[i].getLength() == code.length) {
                 return (stdList[i].getType());


### PR DESCRIPTION
While working on the RAR5 extraction I noticed that we could replace the custom CRC calculation with the JDK CRC32 class.
This gives a massive performance improvement for large archives (tested 7GB compressed, 51GB uncompressed).

Numbers are from a test writing to a NullOuputStream
current code: 2m 48s ([HTML flamegraph](https://github.com/user-attachments/files/27105344/crc-original.html))
pr: 1m 20s ([HTML flamegraph](https://github.com/user-attachments/files/27105336/crc-java.html))


