### PR TITLE
feat: support random access for files in solid RAR4 archives

### DIFF
--- a/src/main/java/com/github/junrar/Archive.java
+++ b/src/main/java/com/github/junrar/Archive.java
@@ -120,6 +120,11 @@ public class Archive implements Closeable, Iterable<FileHeader> {
     private int currentHeaderIndex;
 
     /**
+     * Tracks the highest file index processed in the current solid stream.
+     */
+    private int lastProcessedFileIndex = -1;
+
+    /**
      * Size of packed data in current file.
      */
     private long totalPackedSize = 0L;
@@ -572,13 +577,74 @@ public class Archive implements Closeable, Iterable<FileHeader> {
             throw new HeaderNotInArchiveException();
         }
         try {
+            int targetIdx = getFileHeaderIndex(hd);
+            boolean isSolidStream = newMhd.isSolid() || hd.isSolid();
+
+            if (isSolidStream) {
+                List<FileHeader> fileHeaders = getFileHeaders();
+                if (targetIdx < lastProcessedFileIndex) {
+                    resetSolidStream(fileHeaders);
+                    lastProcessedFileIndex = -1;
+                }
+                for (int i = lastProcessedFileIndex + 1; i < targetIdx; i++) {
+                    skipFile(fileHeaders.get(i));
+                }
+            }
             doExtractFile(hd, os);
+            lastProcessedFileIndex = targetIdx;
         } catch (final Exception e) {
             if (e instanceof RarException) {
                 throw (RarException) e;
             } else {
                 throw new RarException(e);
             }
+        }
+    }
+
+    private int getFileHeaderIndex(FileHeader target) throws HeaderNotInArchiveException {
+        List<FileHeader> fileHeaders = getFileHeaders();
+        for (int i = 0; i < fileHeaders.size(); i++) {
+            if (fileHeaders.get(i) == target) {
+                return i;
+            }
+        }
+        throw new HeaderNotInArchiveException();
+    }
+
+    private void resetSolidStream(List<FileHeader> fileHeaders) throws IOException, RarException {
+        FileHeader firstFile = fileHeaders.get(0);
+        long startPos = firstFile.getPositionInFile() + firstFile.getHeaderSize(isEncrypted());
+        getChannel().setPosition(startPos);
+        if (unpack != null) {
+            unpack.init(null);
+        }
+        dataIO.init((OutputStream) null);
+    }
+
+    private void skipFile(FileHeader skipHd) {
+        if (skipHd.getFullUnpackSize() <= 0) {
+            return;
+        }
+        boolean origTest = dataIO.isTestMode();
+        boolean origSkip = dataIO.isSkipUnpCRC();
+        try {
+            dataIO.setTestMode(true);
+            dataIO.setSkipUnpCRC(true);
+            doExtractFile(skipHd, new NullOutputStream(), true);
+        } catch (RarException e) {
+            logger.warn("Error skipping file {}: {}", skipHd.getFileName(), e.getMessage());
+        } catch (IOException e) {
+            logger.warn("IO error skipping file {}: {}", skipHd.getFileName(), e.getMessage());
+        } finally {
+            dataIO.setTestMode(origTest);
+            dataIO.setSkipUnpCRC(origSkip);
+        }
+    }
+
+    private static class NullOutputStream extends OutputStream {
+        @Override
+        public void write(int b) {
+            // No-op
         }
     }
 
@@ -717,6 +783,11 @@ public class Archive implements Closeable, Iterable<FileHeader> {
 
     private void doExtractFile(FileHeader hd, final OutputStream os)
         throws RarException, IOException {
+        doExtractFile(hd, os, false);
+    }
+
+    private void doExtractFile(FileHeader hd, final OutputStream os, boolean skip)
+        throws RarException, IOException {
         this.dataIO.init(os);
         this.dataIO.init(hd);
         this.dataIO.setUnpFileCRC(this.isOldFormat() ? 0 : 0xffFFffFF);
@@ -729,13 +800,15 @@ public class Archive implements Closeable, Iterable<FileHeader> {
         this.unpack.setDestSize(hd.getFullUnpackSize());
         try {
             this.unpack.doUnpack(hd.getUnpVersion(), hd.isSolid());
-            // Verify file CRC
-            hd = this.dataIO.getSubHeader();
-            final long actualCRC = hd.isSplitAfter() ? ~this.dataIO.getPackedCRC()
-                : ~this.dataIO.getUnpFileCRC();
-            final int expectedCRC = hd.getFileCRC();
-            if (actualCRC != expectedCRC) {
-                throw new CrcErrorException();
+            if (!skip) {
+                // Verify file CRC
+                hd = this.dataIO.getSubHeader();
+                final long actualCRC = hd.isSplitAfter() ? ~this.dataIO.getPackedCRC()
+                    : ~this.dataIO.getUnpFileCRC();
+                final int expectedCRC = hd.getFileCRC();
+                if (actualCRC != expectedCRC) {
+                    throw new CrcErrorException();
+                }
             }
             // if (!hd.isSplitAfter()) {
             // // Verify file CRC
@@ -746,7 +819,6 @@ public class Archive implements Closeable, Iterable<FileHeader> {
         } catch (final Exception e) {
             this.unpack.cleanUp();
             if (e instanceof RarException) {
-                // throw new RarException((RarException)e);
                 throw (RarException) e;
             } else {
                 throw new RarException(e);

--- a/src/main/java/com/github/junrar/Archive.java
+++ b/src/main/java/com/github/junrar/Archive.java
@@ -573,17 +573,21 @@ public class Archive implements Closeable, Iterable<FileHeader> {
      * @throws RarException .
      */
     public void extractFile(final FileHeader hd, final OutputStream os) throws RarException {
-        if (!this.headers.contains(hd)) {
+        List<FileHeader> fileHeaders = getFileHeaders();
+        int targetIdx = fileHeaders.indexOf(hd);
+        if (targetIdx < 0) {
             throw new HeaderNotInArchiveException();
         }
         try {
-            int targetIdx = getFileHeaderIndex(hd);
             boolean isSolidStream = newMhd.isSolid() || hd.isSolid();
 
             if (isSolidStream) {
-                List<FileHeader> fileHeaders = getFileHeaders();
                 if (targetIdx < lastProcessedFileIndex) {
-                    resetSolidStream(fileHeaders);
+                    // Reset the dictionary unconditionally: doExtractFile only resets it when
+                    // the first file is non-solid, which malformed archives may violate.
+                    if (unpack != null) {
+                        unpack.init(null);
+                    }
                     lastProcessedFileIndex = -1;
                 }
                 for (int i = lastProcessedFileIndex + 1; i < targetIdx; i++) {
@@ -601,43 +605,16 @@ public class Archive implements Closeable, Iterable<FileHeader> {
         }
     }
 
-    private int getFileHeaderIndex(FileHeader target) throws HeaderNotInArchiveException {
-        List<FileHeader> fileHeaders = getFileHeaders();
-        for (int i = 0; i < fileHeaders.size(); i++) {
-            if (fileHeaders.get(i) == target) {
-                return i;
-            }
-        }
-        throw new HeaderNotInArchiveException();
-    }
-
-    private void resetSolidStream(List<FileHeader> fileHeaders) throws IOException, RarException {
-        FileHeader firstFile = fileHeaders.get(0);
-        long startPos = firstFile.getPositionInFile() + firstFile.getHeaderSize(isEncrypted());
-        getChannel().setPosition(startPos);
-        if (unpack != null) {
-            unpack.init(null);
-        }
-        dataIO.init((OutputStream) null);
-    }
-
     private void skipFile(FileHeader skipHd) {
         if (skipHd.getFullUnpackSize() <= 0) {
             return;
         }
-        boolean origTest = dataIO.isTestMode();
-        boolean origSkip = dataIO.isSkipUnpCRC();
         try {
-            dataIO.setTestMode(true);
-            dataIO.setSkipUnpCRC(true);
             doExtractFile(skipHd, new NullOutputStream(), true);
         } catch (RarException e) {
             logger.warn("Error skipping file {}: {}", skipHd.getFileName(), e.getMessage());
         } catch (IOException e) {
             logger.warn("IO error skipping file {}: {}", skipHd.getFileName(), e.getMessage());
-        } finally {
-            dataIO.setTestMode(origTest);
-            dataIO.setSkipUnpCRC(origSkip);
         }
     }
 

--- a/src/main/java/com/github/junrar/unpack/ComprDataIO.java
+++ b/src/main/java/com/github/junrar/unpack/ComprDataIO.java
@@ -211,16 +211,8 @@ public class ComprDataIO {
         testMode = mode;
     }
 
-    public boolean isTestMode() {
-        return testMode;
-    }
-
     public void setSkipUnpCRC(boolean skip) {
         skipUnpCRC = skip;
-    }
-
-    public boolean isSkipUnpCRC() {
-        return skipUnpCRC;
     }
 
     public void setSubHeader(FileHeader hd) {

--- a/src/main/java/com/github/junrar/unpack/ComprDataIO.java
+++ b/src/main/java/com/github/junrar/unpack/ComprDataIO.java
@@ -211,8 +211,16 @@ public class ComprDataIO {
         testMode = mode;
     }
 
+    public boolean isTestMode() {
+        return testMode;
+    }
+
     public void setSkipUnpCRC(boolean skip) {
         skipUnpCRC = skip;
+    }
+
+    public boolean isSkipUnpCRC() {
+        return skipUnpCRC;
     }
 
     public void setSubHeader(FileHeader hd) {

--- a/src/test/java/com/github/junrar/ArchiveTest.java
+++ b/src/test/java/com/github/junrar/ArchiveTest.java
@@ -16,7 +16,6 @@
  */
 package com.github.junrar;
 
-import com.github.junrar.exception.CrcErrorException;
 import com.github.junrar.exception.RarException;
 import com.github.junrar.exception.UnsupportedRarV5Exception;
 import com.github.junrar.rarfile.FileHeader;
@@ -38,6 +37,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -287,7 +287,7 @@ public class ArchiveTest {
         }
 
         @Test
-        public void givenSolidRar4File_whenExtractingOutOfOrder_thenExceptionIsThrown() throws Exception {
+        public void givenSolidRar4File_whenExtractingOutOfOrder_thenExtractionIsDone() throws Exception {
             try (InputStream is = getClass().getResourceAsStream("solid/rar4-solid.rar")) {
                 try (Archive archive = new Archive(is)) {
                     assertThat(archive.getMainHeader().isSolid()).isTrue();
@@ -295,10 +295,42 @@ public class ArchiveTest {
                     List<FileHeader> fileHeaders = archive.getFileHeaders();
                     assertThat(fileHeaders).hasSize(9);
 
+                    // Extract file 5 (index 4) out of order - should skip files 1-4
                     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-                        Throwable thrown = catchThrowable(() -> archive.extractFile(fileHeaders.get(4), baos));
+                        archive.extractFile(fileHeaders.get(4), baos);
+                        assertThat(baos.toString()).isEqualTo("file5\n");
+                    }
 
-                        assertThat(thrown).isExactlyInstanceOf(CrcErrorException.class);
+                    // Extract file 2 (index 1) - backward access should reset and re-process
+                    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                        archive.extractFile(fileHeaders.get(1), baos);
+                        assertThat(baos.toString()).isEqualTo("file2\n");
+                    }
+
+                    // Extract file 9 (index 8) - forward access after backward access
+                    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                        archive.extractFile(fileHeaders.get(8), baos);
+                        assertThat(baos.toString()).isEqualTo("file9\n");
+                    }
+                }
+            }
+        }
+
+        @Test
+        public void givenSolidRar4File_whenExtractingInReverse_theExtractionIsDone() throws Exception {
+            try (InputStream is = getClass().getResourceAsStream("solid/rar4-solid.rar");
+                 Archive archive = new Archive(is)) {
+                assertThat(archive.getMainHeader().isSolid()).isTrue();
+
+                List<FileHeader> fileHeaders = archive.getFileHeaders();
+                assertThat(fileHeaders).hasSize(9);
+                Collections.reverse(fileHeaders);
+
+                for (FileHeader fileHeader : fileHeaders) {
+                    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                        archive.extractFile(fileHeader, baos);
+                        String expected = fileHeader.getFileName().replace(".txt", "") + "\n";
+                        assertThat(baos.toString()).isEqualTo(expected);
                     }
                 }
             }


### PR DESCRIPTION
Implements out-of-order file extraction from solid archives, matching unrar's behavior of sequential processing with skip mode:

- Forward access: skip preceding files by decompressing without writing output or checking CRC
- Backward access: reset solid stream and re-process from start